### PR TITLE
Rename DomestiClaw → Writ across all MD files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-DomestiClaw is a self-improving, locally-deployed multi-agent system inspired by OpenClaw with a security-first redesign. The core analogy is "agent as a self-expanding OS." The system routes user requests through an Orchestrator → [*Planner*](docs/dictionary.md) → Executor → shell script pipeline, with each agent's output reviewed before proceeding.
+Writ is a self-improving, locally-deployed multi-agent system inspired by OpenClaw with a security-first redesign. The core analogy is "agent as a self-expanding OS." The system routes user requests through an Orchestrator → [*Planner*](docs/dictionary.md) → Executor → shell script pipeline, with each agent's output reviewed before proceeding.
 
 ## Build & Run
 

--- a/dist/instance/identity/SOUL.md
+++ b/dist/instance/identity/SOUL.md
@@ -2,13 +2,13 @@
 
 ## Identity
 
-You are DomestiClaw, a personal assistant system. You are helpful, direct, and transparent about your capabilities and limitations.
+You are Writ, a personal assistant system. You are helpful, direct, and transparent about your capabilities and limitations.
 
 ## Presentation
 
 - Communicate clearly and concisely
 - When you don't know something, say so
-- Identify yourself as DomestiClaw when asked
+- Identify yourself as Writ when asked
 - Attribute work to the specific agent that performed it when relevant
 
 ## Personality

--- a/docs/architecture/Overview.md
+++ b/docs/architecture/Overview.md
@@ -1,4 +1,4 @@
-# DomestiClaw Architecture Overview
+# Writ Architecture Overview
 
 > **This document (and the entire set in docs/architecture) describes the intended design — not current implementation state.** For what is built vs. what is planned, see `docs/planning/Roadmap.md`.
 
@@ -12,7 +12,7 @@ The goal is to mutate the architecture and find something less insecure. The ana
 
 Linux as a concept is like... a set of filesystems, each serving a different purpose, each maintained by a set of authors. When some user instantiates it, they take the basic set of files and customize it the way they want it. It's just a big list of files, with different permissions. The user can choose which files to modify, which to add, in order to give the system different capabilities.
 
-Similarly, DomestiClaw should be a set of files, executables, best practices. Different versions will be maintained for different purposes by different authors. The difference is that it can modify (certain parts of) itself, and act as an author.
+Similarly, Writ should be a set of files, executables, best practices. Different versions will be maintained for different purposes by different authors. The difference is that it can modify (certain parts of) itself, and act as an author.
 
 It should be a capable user of an OS - it should seek updates at intervals, or use the tools provided by the system (cron jobs to start package manager updates) to do so. It should download software, having considered whether the software is fit for the purpose, and secure enough for the purpose such that side effects are not undesirable.
 
@@ -107,12 +107,12 @@ The function's code is not editable by agents (at least not until the system pro
 
 ## Filesystem Layout
 
-The filesystem separates **building DomestiClaw** (project tooling, source code, docs) from **running an instance** (identity, scripts, runtime output). Everything a running instance needs lives under `src/instance/` in source and `dist/instance/` after build.
+The filesystem separates **building Writ** (project tooling, source code, docs) from **running an instance** (identity, scripts, runtime output). Everything a running instance needs lives under `src/instance/` in source and `dist/instance/` after build.
 
 ```
-domestiClaw/
+writ/
 │
-│ ── INSTANCE INPUTS (what a running DomestiClaw is) ──────────────
+│ ── INSTANCE INPUTS (what a running Writ is) ──────────────
 │
 ├── src/
 │   ├── instance/              # Assets that ship with an instance
@@ -196,7 +196,7 @@ domestiClaw/
 │       ├── identity/          #     (same structure as source)
 │       └── scripts/
 │
-│ ── PROJECT (building DomestiClaw, not used by instances) ────────
+│ ── PROJECT (building Writ, not used by instances) ────────
 │
 ├── docs/                      # Design documentation (human-facing)
 │   ├── architecture/          #   Specs (this file, agent specs, models)
@@ -231,7 +231,7 @@ domestiClaw/
 ```
 
 **Key distinctions:**
-- `src/instance/` = what a DomestiClaw instance *is*: identity (LLM context) + scripts (capabilities). Copied to `dist/` on build.
+- `src/instance/` = what a Writ instance *is*: identity (LLM context) + scripts (capabilities). Copied to `dist/` on build.
 - `src/` (rest) = deterministic code (what the agents *do*). Compiled to `dist/` on build. Not self-modifiable.
 - `dist/` = self-contained deployable. Compiled JS + instance assets. Gitignored.
 - `runtime/` = ephemeral instance output. *Plan*, logs. Gitignored. Safe to delete.
@@ -239,13 +239,13 @@ domestiClaw/
 
 ## Design Intent
 
-An OS-oriented mentality for maintaining a DomestiClaw instance would create a repository of vetted scripts and tools to accomplish tasks. It would include documentation about which software is good for which purposes, and what side effects or security implications exist.
+An OS-oriented mentality for maintaining a Writ instance would create a repository of vetted scripts and tools to accomplish tasks. It would include documentation about which software is good for which purposes, and what side effects or security implications exist.
 
-It will certainly fail to do the correct thing in early iterations. But just as the open source community around Linux has settled on good practices, a community built around refining DomestiClaw could come to a workable set of solutions whereby the adjutant could make reasonable decisions about using the set of available scripts and software to effectively complete user requests.
+It will certainly fail to do the correct thing in early iterations. But just as the open source community around Linux has settled on good practices, a community built around refining Writ could come to a workable set of solutions whereby the adjutant could make reasonable decisions about using the set of available scripts and software to effectively complete user requests.
 
 ## Design Lineage
 
-DomestiClaw is a security-first redesign of OpenClaw. For the specific design decisions inherited from OpenClaw and the rationale behind them, see [docs/background/OpenClawRationale.md](../background/OpenClawRationale.md).
+Writ is a security-first redesign of OpenClaw. For the specific design decisions inherited from OpenClaw and the rationale behind them, see [docs/background/OpenClawRationale.md](../background/OpenClawRationale.md).
 
 ## Agent Classes Overview
 
@@ -421,4 +421,4 @@ This subsystem's design is tracked in [OpenQuestions.md §11](../planning/OpenQu
 
 ## Meta-System
 
-A larger meta-system spins up instances of DomestiClaw, runs them for a while, notes issues, and curates/maintains creation of new instances. This allows experimentation and iteration without requiring all work to be done by human hands. The meta-system informs design decisions around logging and Review Flags — specifically, what gets logged and how flags propagate must be compatible with meta-tier analysis. See [OpenQuestions.md §15](../planning/OpenQuestions.md#15-the-meta-tier-process) for open design questions.
+A larger meta-system spins up instances of Writ, runs them for a while, notes issues, and curates/maintains creation of new instances. This allows experimentation and iteration without requiring all work to be done by human hands. The meta-system informs design decisions around logging and Review Flags — specifically, what gets logged and how flags propagate must be compatible with meta-tier analysis. See [OpenQuestions.md §15](../planning/OpenQuestions.md#15-the-meta-tier-process) for open design questions.

--- a/docs/background/sample-pipeline-trace.md
+++ b/docs/background/sample-pipeline-trace.md
@@ -111,7 +111,7 @@ LP detects `missingScripts` is non-empty. Calls `generateScript()` with the capa
 # @param SEPARATOR Optional separator between files (defaults to a filename header comment)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ALLOWED_ROOT="${DOMESTICLAW_ALLOWED_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+ALLOWED_ROOT="${WRIT_ALLOWED_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 
 if [ -z "$SOURCE_DIR" ]; then
   echo "Error: SOURCE_DIR is required" >&2

--- a/docs/dictionary.md
+++ b/docs/dictionary.md
@@ -25,7 +25,7 @@ An agent that produces structured plans consumed by other agents. Planner output
 → See [Overview.md § Agent Classes Overview](architecture/Overview.md#agent-classes-overview) for class-level documentation.
 
 ## *AgentOS*
-The DomestiClaw agent ecosystem: the set of agents, scripts, identity files, and infrastructure that constitute a running instance. DomestiClaw is an *AgentOS*. OpenClaw is an insecure one.
+The Writ agent ecosystem: the set of agents, scripts, identity files, and infrastructure that constitute a running instance. Writ is an *AgentOS*. OpenClaw is an insecure one.
 
 ## *Anti-pattern List*
 An append-only per-agent file (e.g., `anti-patterns-developer.md`) recording known problematic patterns. *Reviewers* read these but do not write directly — appends are triggered by *Reviewer-Reviewer* flags or meta-tier tooling.

--- a/docs/planning/OpenQuestions.md
+++ b/docs/planning/OpenQuestions.md
@@ -1,4 +1,4 @@
-# DomestiClaw — Open Design Questions
+# Writ — Open Design Questions
 
 Decisions made and questions still open, organized by subsystem.
 This is a living document. Move items from "Open" to the appropriate Phase in `Roadmap.md` once decided.

--- a/docs/planning/Roadmap.md
+++ b/docs/planning/Roadmap.md
@@ -1,4 +1,4 @@
-# DomestiClaw Implementation Roadmap
+# Writ Implementation Roadmap
 
 ### Key Files
 See `CLAUDE.md` for the full source file map.
@@ -104,7 +104,7 @@ graph LR
 - Falls back to rule-based reviewer on parse/API failure
 
 ### 2.6 Configurable ALLOWED_ROOT + Bootstrap Scripts `[x]` (completed 2026-02-20)
-- `ALLOWED_ROOT` computed from `$0` at runtime; overridable via `DOMESTICLAW_ALLOWED_ROOT`
+- `ALLOWED_ROOT` computed from `$0` at runtime; overridable via `WRIT_ALLOWED_ROOT`
 - 3 new bootstrap scripts: `git-status`, `append-file`, `search-content`
 
 ### 2.6.5 XYZ-AGENT.md Rewrite `[x]` (completed 2026-02-20)
@@ -174,7 +174,7 @@ These require the full Phase 2 review chain before they're safe to build. Develo
 
 *Tier 7 — Speculative*
 
-- **(24)** **ClawdBot Integration & Untrusted Execution** *(Backlog)*: Sandbox model for imported skills/agents outside DomestiClaw's review chain. When the core system is solid. See [`docs/planning/backlog/backlog-clawdbot.md`](backlog/backlog-clawdbot.md).
+- **(24)** **ClawdBot Integration & Untrusted Execution** *(Backlog)*: Sandbox model for imported skills/agents outside Writ's review chain. When the core system is solid. See [`docs/planning/backlog/backlog-clawdbot.md`](backlog/backlog-clawdbot.md).
 
 ---
 

--- a/docs/planning/backlog/backlog-branch-workflow.md
+++ b/docs/planning/backlog/backlog-branch-workflow.md
@@ -18,7 +18,7 @@ Once Developer/Writer is live and producing scripts, there needs to be a gate be
 
 **Human override**: The human operator can review and merge (or close) any PR via the Gitea UI. The agent review is not the only path to merge.
 
-**Dogfooding note**: Switching to a branch workflow for DomestiClaw's own development (before this feature is built) is worthwhile — it makes the workflow concrete and surfaces any friction before agents have to deal with it.
+**Dogfooding note**: Switching to a branch workflow for Writ's own development (before this feature is built) is worthwhile — it makes the workflow concrete and surfaces any friction before agents have to deal with it.
 
 ## Open Questions
 - Is Code-Reviewing-Agent a new agent class or a specialized mode of Developer-Reviewer?

--- a/docs/planning/backlog/backlog-clawdbot.md
+++ b/docs/planning/backlog/backlog-clawdbot.md
@@ -1,10 +1,10 @@
 # ClawdBot Integration & Untrusted Execution
 
 ## Summary
-A potential sandbox model for imported ClawdBot skills and agents that lack DomestiClaw-native review guarantees. Also covers a vetting pipeline to transform imported skills into proper DomestiClaw scripts or agents.
+A potential sandbox model for imported ClawdBot skills and agents that lack Writ-native review guarantees. Also covers a vetting pipeline to transform imported skills into proper Writ scripts or agents.
 
 ## Motivation
-ClawdBot and similar systems may offer useful capabilities that would be expensive to replicate. The question is whether DomestiClaw can host agents or skills from outside its own review chain — and if so, under what containment model.
+ClawdBot and similar systems may offer useful capabilities that would be expensive to replicate. The question is whether Writ can host agents or skills from outside its own review chain — and if so, under what containment model.
 
 ## Design Notes
 

--- a/docs/planning/backlog/backlog-containerization.md
+++ b/docs/planning/backlog/backlog-containerization.md
@@ -4,7 +4,7 @@
 AgentOS ships as a self-contained deployable container. All internal services — Gitea, script runner, logs, dashboard — run inside it. A user deploys one container and gets a fully functional instance.
 
 ## Motivation
-The "agent as a self-expanding OS" analogy implies a deployable unit, not a manual install process. Containerization is what makes DomestiClaw an artifact you hand someone rather than a setup procedure. It's also the prerequisite for Gitea and the web dashboard running inside the instance boundary.
+The "agent as a self-expanding OS" analogy implies a deployable unit, not a manual install process. Containerization is what makes Writ an artifact you hand someone rather than a setup procedure. It's also the prerequisite for Gitea and the web dashboard running inside the instance boundary.
 
 ## Design Notes
 Internal services (Gitea, etc.) are embedded rather than sidecars — consistent with the project philosophy of self-containment. The instance could conceivably swap internal services later; the stable boundary is the container's external interface, not which software runs inside.

--- a/docs/planning/backlog/backlog-scenario-ci.md
+++ b/docs/planning/backlog/backlog-scenario-ci.md
@@ -1,7 +1,7 @@
 # Scenario CI via Claude Code Web
 
 ## Summary
-Use Claude Code web sessions as an automated integration testing environment. Each session boots a clean DomestiClaw instance, feeds it behavioral scenarios, observes results, and validates that the system performs as expected — including script authoring, review, and execution. Doubles as a self-improvement smoke test: can the system write useful scripts and make progress on real tasks without human intervention?
+Use Claude Code web sessions as an automated integration testing environment. Each session boots a clean Writ instance, feeds it behavioral scenarios, observes results, and validates that the system performs as expected — including script authoring, review, and execution. Doubles as a self-improvement smoke test: can the system write useful scripts and make progress on real tasks without human intervention?
 
 ## Motivation
 Unit tests verify individual components. Scenario CI verifies the *system* — the full agent chain operating on real LLM calls against real tasks. The ephemeral nature of Claude Code web sessions is an asset: every run starts from a clean repo clone (the "base shipped instance"), so tests are reproducible and state pollution is impossible.

--- a/docs/planning/backlog/backlog.md
+++ b/docs/planning/backlog/backlog.md
@@ -13,7 +13,7 @@ Each item has a file in this directory. This index lists them in rough priority 
 5. **Gitea Integration** (`backlog-gitea.md`) — Embedded Gitea for script repo hosting and human inspection.
 6. **Script Branch Workflow + Code-Reviewing-Agent** (`backlog-branch-workflow.md`) — Scripts developed on branches, merged via reviewed PR.
 7. **Web Dashboard** (`backlog-dashboard.md`) — Browser UI for system visibility, job status, review history, FAFC resolution.
-8. **ClawdBot Integration & Untrusted Execution** (`backlog-clawdbot.md`) — Sandbox model for imported skills/agents outside DomestiClaw's review chain.
+8. **ClawdBot Integration & Untrusted Execution** (`backlog-clawdbot.md`) — Sandbox model for imported skills/agents outside Writ's review chain.
 9. **BIG_BROTHER Proactive Config Optimization** (`backlog-bb-optimization.md`) — Proactive mode for BB: analyzes execution logs and proposes config improvements on a per-invocation threshold, not just in response to RR flags.
 10. **Developer/Writer Branch-Based Script Staging** (`backlog-dw-branch-staging.md`) — Replace flat staging dir with git branch per DW session. Depends on Gitea integration.
 11. **Scenario CI via Claude Code Web** (`backlog-scenario-ci.md`) — Automated behavioral testing using ephemeral Claude Code web sessions as integration test environments. Validates end-to-end pipeline and self-authoring capability.

--- a/docs/working/fold-me-in.md
+++ b/docs/working/fold-me-in.md
@@ -1,4 +1,4 @@
-# DomestiClaw Spec — Changes to Apply
+# Writ Spec — Changes to Apply
 
 Directives for updating architecture source docs. Apply to files in `docs/architecture/`, `docs/planning/`, and `docs/planning/backlog`.
 

--- a/src/instance/identity/SOUL.md
+++ b/src/instance/identity/SOUL.md
@@ -2,13 +2,13 @@
 
 ## Identity
 
-You are DomestiClaw, a personal assistant system. You are helpful, direct, and transparent about your capabilities and limitations.
+You are Writ, a personal assistant system. You are helpful, direct, and transparent about your capabilities and limitations.
 
 ## Presentation
 
 - Communicate clearly and concisely
 - When you don't know something, say so
-- Identify yourself as DomestiClaw when asked
+- Identify yourself as Writ when asked
 - Attribute work to the specific agent that performed it when relevant
 
 ## Personality

--- a/src/instance/identity/agents/developer-writer-agent.md
+++ b/src/instance/identity/agents/developer-writer-agent.md
@@ -27,7 +27,7 @@ Every script MUST include frontmatter comments at the top:
 
 ```bash
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ALLOWED_ROOT="${DOMESTICLAW_ALLOWED_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+ALLOWED_ROOT="${WRIT_ALLOWED_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 ```
 
 - **Validate inputs.** Check that required params are non-empty. Exit with code 1 and a clear error message on failure.
@@ -44,7 +44,7 @@ ALLOWED_ROOT="${DOMESTICLAW_ALLOWED_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 # @param FILE_PATH Path to the file to count
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ALLOWED_ROOT="${DOMESTICLAW_ALLOWED_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+ALLOWED_ROOT="${WRIT_ALLOWED_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 
 if [ -z "$FILE_PATH" ]; then
   echo "Error: FILE_PATH is required" >&2


### PR DESCRIPTION
Updates all Markdown files to reflect the project rename from
DomestiClaw to Writ: CLAUDE.md, SOUL.md (src + dist), architecture
Overview, Roadmap, OpenQuestions, dictionary, fold-me-in, all backlog
files, sample-pipeline-trace, and developer-writer-agent. Also renames
the DOMESTICLAW_ALLOWED_ROOT env var reference to WRIT_ALLOWED_ROOT in
MD code examples.

https://claude.ai/code/session_01W3G7gQsbGCBgY8xeYPgqgR