### PR TITLE
Add workflow slash commands and ADR template

### DIFF
--- a/.claude/commands/rectify.md
+++ b/.claude/commands/rectify.md
@@ -1,0 +1,72 @@
+Scan for inconsistencies between the documentation and the actual codebase. Work through each check below, then print a summary report of all findings.
+
+Do NOT create GitHub Issues during this run — just report findings. (Issue creation requires `gh` auth; check with `gh auth status` first and skip if not available.)
+
+---
+
+## Check 1: Docs describing things not in code
+
+Read `docs/architecture/` files. For each component, agent, or system described, verify that corresponding source files exist in `src/`.
+
+Key mappings to check:
+- Each agent described in `docs/architecture/agents/` → corresponding file in `src/agents/`
+- Each component in `docs/architecture/components/` → corresponding file in `src/`
+- Script references in docs → actual scripts in `src/instance/scripts/`
+- Registry entries in `src/instance/identity/registry.json` → actual agent implementations
+
+Report: doc references with no corresponding code.
+
+## Check 2: Code implementing things not in docs
+
+List all files in `src/agents/` and `src/instance/scripts/`. Check each against:
+- `docs/architecture/` for design documentation
+- `CLAUDE.md` Key Source Files section
+- `docs/planning/Roadmap.md` Component Status table
+
+Report: implemented files with no documentation or roadmap entry.
+
+## Check 3: Stale references and broken internal links
+
+Scan all `.md` files in `docs/` for:
+- Links to files that don't exist (both relative paths and anchors)
+- References to source files by path that have moved or been deleted
+- Cross-references to other docs that have been renamed
+
+Run: `grep -r "\[.*\](.*\.md)" docs/ --include="*.md" -o` and verify each target exists.
+
+## Check 4: OpenQuestions.md items resolved in code
+
+Read `docs/planning/OpenQuestions.md`. For each **Open** item, check whether the described question now has an answer visible in the codebase (implemented code, tests, or a "Decided" annotation added).
+
+Report: open questions where the code suggests a decision has been made but the doc hasn't been updated.
+
+## Check 5: TODO/placeholder content in spec docs
+
+Scan `docs/architecture/` and `docs/planning/` for:
+- Sections containing "TBD", "TODO", "placeholder", "PLACEHOLDER", "to be determined", "fill in"
+- Empty sections (header with no content)
+- Spec stubs that should either be fleshed out or converted to tracked issues
+
+Report each instance with file, section header, and the placeholder text.
+
+## Check 6: CLAUDE.md accuracy
+
+Compare `CLAUDE.md` Key Source Files section against actual `src/` contents:
+- Files listed in CLAUDE.md that don't exist
+- Files in `src/agents/` not listed in CLAUDE.md
+- Wiring diagram in CLAUDE.md vs. actual call graph (check orchestrator.ts, planner.ts, lieutenant-planner.ts imports)
+
+---
+
+## Output format
+
+Print a report with one section per check. For each finding:
+
+```
+[CHECK N] <short description>
+  File: <path>
+  Detail: <what's wrong>
+  Suggested action: <fix doc | fix code | create issue | investigate>
+```
+
+End with a summary count: X findings across Y checks. Note any checks that were skipped and why.

--- a/.claude/commands/state-of-system.md
+++ b/.claude/commands/state-of-system.md
@@ -1,0 +1,94 @@
+Generate `docs/STATE_OF_SYSTEM.md` by inspecting the actual codebase. Do NOT copy from other docs — derive everything by reading source files directly. Regenerate from scratch each time (overwrite the file completely).
+
+Work through each section below, then write the full file.
+
+---
+
+## Section 1: What's built and working
+
+For each agent in `src/agents/`, check:
+1. Does a corresponding test file exist (`*.test.ts`)?
+2. Run `npm test` — do those tests pass?
+
+List agents/components as **built and tested** only if tests exist AND pass. List as **built, untested** if the file exists but has no test coverage.
+
+Also check `src/compiler/`, `src/scripts/`, `src/io/`, `src/jobs/`, `src/sessions.ts`, `src/identity/`.
+
+## Section 2: What's stubbed or scaffolded
+
+Look for:
+- Files with functions that `return null`, `return {}`, throw `new Error('not implemented')`, or have bodies that are just comments
+- Files imported in the pipeline but whose functions are never called with real data
+- Specifically check `src/agents/semantic-review.ts` (known stub)
+
+Report each as: file path, function name, nature of stub.
+
+## Section 3: Agent pipeline topology
+
+Read these files to reconstruct the actual call graph:
+- `src/agents/orchestrator.ts` — what does `handleRequest()` call?
+- `src/agents/planner.ts` — what does `createStrategicPlan()` call?
+- `src/agents/lieutenant-planner.ts` — what does `createDetailedPlanWithDW()` call?
+- `src/agents/executor.ts` — what does `executeFromPlan()` call?
+- `src/compiler/compiler.ts` — what does `compile()` call?
+- `src/agents/reviewed.ts` — what does `applyReview()` call?
+
+Draw the pipeline as a text diagram showing: agent name → what it calls → what returns.
+
+## Section 4: Active adapters and integrations
+
+Read `src/io/`:
+- List each IOAdapter implementation and whether it's wired into `src/index.ts`
+- Note TestAdapter (integration tests only)
+
+Read `src/agents/claude-client.ts` and `src/agents/ollama-client.ts`:
+- Which providers are implemented?
+- Which is active by default?
+- What env vars control switching?
+
+## Section 5: Test coverage summary
+
+Run `npm test -- --reporter=verbose 2>&1` and `npm run test:integration -- --reporter=verbose 2>&1`
+
+Report:
+- Total test files
+- Total tests (pass/fail/skip) per suite
+- Which agents/components have test coverage vs. none
+
+## Section 6: Known gaps and tech debt
+
+Read `docs/planning/Roadmap.md` Technical Debt section and `docs/planning/OpenQuestions.md`.
+
+List items where: the roadmap says `[ ]` (not done) AND there is no corresponding code stub. These are genuine gaps, not stubs.
+
+---
+
+## Output
+
+Write the complete file to `docs/STATE_OF_SYSTEM.md` with this structure:
+
+```markdown
+# State of System
+
+_Generated: <today's date>. Reflects actual codebase — not aspirational docs._
+
+## Built and Working
+...
+
+## Stubbed / Scaffolded
+...
+
+## Agent Pipeline Topology
+...
+
+## Active Adapters and Integrations
+...
+
+## Test Coverage
+...
+
+## Known Gaps
+...
+```
+
+Confirm after writing: "STATE_OF_SYSTEM.md written."

--- a/.claude/commands/summarize.md
+++ b/.claude/commands/summarize.md
@@ -1,0 +1,42 @@
+Produce a development summary covering the current state of this repository. Work through each section below and output the results as clean markdown suitable for pasting into a planning conversation.
+
+## 1. PRs merged since last summary
+
+Run: `git log --oneline --merges origin/main --since="30 days ago"`
+
+List each merged PR on one line: PR number (if visible in commit message), title, date.
+
+## 2. Open branches / in-progress work
+
+Run: `git branch -r | grep -v HEAD | grep -v origin/main`
+
+List each branch. For branches starting with `claude/`, note the task description encoded in the name.
+
+## 3. Current GitHub Issues by label
+
+Run: `gh issue list --label "on-deck"`, `gh issue list --label "needs-refinement"`, `gh issue list --label "blocked"`
+
+Group results under each label. If `gh` is not authenticated, note that issue tracking is unavailable and skip this section.
+
+## 4. Test suite status
+
+Run unit tests: `npm test`
+Run integration tests: `npm run test:integration`
+
+Report: total tests, passed, failed, skipped for each suite. If tests fail, list the failing test names.
+
+## 5. Notable recent changes to architecture docs or key files
+
+Run: `git diff --name-only origin/main HEAD` and `git log --oneline -20 --name-only`
+
+Highlight any changes to: `CLAUDE.md`, `docs/architecture/`, `docs/planning/Roadmap.md`, `src/agents/`, `src/types.ts`, `src/schemas.ts`.
+
+## 6. TODOs and open questions in code
+
+Run: `grep -r "TODO\|FIXME\|HACK\|XXX" src/ --include="*.ts" -n`
+
+List findings grouped by file. Skip noise — focus on actionable items.
+
+---
+
+Format the output as scannable markdown sections. Be concise. No fluff.

--- a/docs/decisions/TEMPLATE.md
+++ b/docs/decisions/TEMPLATE.md
@@ -1,0 +1,19 @@
+# ADR-NNNN: [Title]
+
+## Status
+[Proposed | Accepted | Superseded by ADR-XXXX]
+
+## Context
+[What situation prompted this decision?]
+
+## Options Considered
+[What alternatives were evaluated?]
+
+## Decision
+[What was chosen?]
+
+## Rationale
+[Why?]
+
+## Consequences
+[What changes as a result?]


### PR DESCRIPTION
- .claude/commands/summarize.md: dev summary (PRs, branches, issues, test status, notable changes, TODOs)
- .claude/commands/rectify.md: doc/code consistency scan with actionable findings report
- .claude/commands/state-of-system.md: regenerates docs/STATE_OF_SYSTEM.md from live codebase inspection
- docs/decisions/: new directory with ADR TEMPLATE.md for architecture decision records

https://claude.ai/code/session_01JsYKMjkHay93YLbyfgwxzq