### PR TITLE
feat(jobs): implement DefaultJobExecutor routing job types to pipeline agents

### DIFF
--- a/src/integration/pipeline.integration.test.ts
+++ b/src/integration/pipeline.integration.test.ts
@@ -24,6 +24,9 @@ import { loadIdentity } from "../identity/loader.js";
 import { createClaudeClient } from "../agents/claude-client.js";
 import { createTestAdapter } from "../io/TestAdapter.js";
 import { createMockLLMClient } from "../test-utils/MockLLMClient.js";
+import { createJobStore } from "../jobs/store.js";
+import { createScheduler } from "../jobs/scheduler.js";
+import { createDefaultJobExecutor } from "../jobs/defaultExecutor.js";
 import type { LLMClient } from "../agents/claude-client.js";
 import type { IdentityContext } from "../types.js";
 
@@ -392,6 +395,63 @@ describe("5. Developer/Writer Trigger", () => {
       // Pipeline completed without error
       expect(result.response).toBeTruthy();
       expect(adapter.collected.errors).toHaveLength(0);
+    },
+    30_000
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Test 6 — DefaultJobExecutor + Scheduler Integration  (mock-only)
+//
+// Validates: Scheduler + DefaultJobExecutor wiring end-to-end with MockLLMClient.
+// Submits a "plan" job, runs the scheduler, verifies the job completes with a
+// plan structure.
+// ---------------------------------------------------------------------------
+
+describe("6. DefaultJobExecutor + Scheduler", () => {
+  it.skipIf(USE_REAL_LLM)(
+    "plan job completes through scheduler + DefaultJobExecutor and returns a plan structure",
+    async () => {
+      const jobsDir = await mkdtemp(join(tmpdir(), "writ-integ-jobs-"));
+      const plansDir = await mkdtemp(join(tmpdir(), "writ-integ-exec-plans-"));
+
+      try {
+        const client = createMockLLMClient();
+        const store = await createJobStore(jobsDir);
+        const executor = createDefaultJobExecutor({
+          client,
+          identity,
+          scriptsDir: INSTANCE_SCRIPTS_DIR,
+          plansDir,
+        });
+        const scheduler = createScheduler(store, executor, undefined);
+
+        const job = await scheduler.submitJob({
+          type: "plan",
+          goal: "Execute the task",
+          dependsOn: [],
+          createdBy: "test",
+          evidence: [],
+          callbacks: [],
+          channel: [],
+        });
+
+        scheduler.tick();
+        const completed = await scheduler.waitForJob(job.id, 15_000);
+
+        expect(completed.status).toBe("completed");
+        expect(completed.result).toBeDefined();
+
+        // Result should be a LieutenantPlanResult with a plan field
+        const result = completed.result as { plan?: { id?: string; steps?: unknown[] }; missingScripts?: unknown[] };
+        expect(result.plan).toBeDefined();
+        expect(result.plan?.id).toBeTruthy();
+        expect(Array.isArray(result.plan?.steps)).toBe(true);
+        expect(Array.isArray(result.missingScripts)).toBe(true);
+      } finally {
+        await rm(jobsDir, { recursive: true, force: true });
+        await rm(plansDir, { recursive: true, force: true });
+      }
     },
     30_000
   );

--- a/src/jobs/defaultExecutor.test.ts
+++ b/src/jobs/defaultExecutor.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createDefaultJobExecutor } from "./defaultExecutor.js";
+import type { Job } from "./types.js";
+import type { IOAdapter } from "../io/IOAdapter.js";
+import type { LLMClient } from "../agents/claude-client.js";
+import type { IdentityContext, Plan } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../agents/executor.js", () => ({
+  executeFromPlan: vi.fn(),
+}));
+
+vi.mock("../agents/developer-writer.js", () => ({
+  generateScript: vi.fn(),
+}));
+
+vi.mock("../agents/lieutenant-planner.js", () => ({
+  createDetailedPlan: vi.fn(),
+}));
+
+vi.mock("../agents/planner.js", () => ({
+  createStrategicPlan: vi.fn(),
+}));
+
+vi.mock("../scripts/index.js", () => ({
+  listScripts: vi.fn(),
+}));
+
+import { executeFromPlan } from "../agents/executor.js";
+import { generateScript } from "../agents/developer-writer.js";
+import { createDetailedPlan } from "../agents/lieutenant-planner.js";
+import { createStrategicPlan } from "../agents/planner.js";
+import { listScripts } from "../scripts/index.js";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const mockClient = {} as LLMClient;
+const mockIdentity = {} as IdentityContext;
+
+const deps = {
+  client: mockClient,
+  identity: mockIdentity,
+  scriptsDir: "/tmp/scripts",
+  plansDir: "/tmp/plans",
+};
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    id: "job-1",
+    type: "execute_script",
+    status: "running",
+    goal: "do something",
+    dependsOn: [],
+    createdBy: "orchestrator",
+    evidence: [],
+    callbacks: [],
+    channel: [],
+    timestamps: { created: "2026-01-01T00:00:00Z" },
+    ...overrides,
+  };
+}
+
+const mockAdapter: IOAdapter = {
+  sendResult: vi.fn().mockResolvedValue(undefined),
+  sendError: vi.fn().mockResolvedValue(undefined),
+  sendReviewBlock: vi.fn().mockResolvedValue(undefined),
+  sendStatus: vi.fn().mockResolvedValue(undefined),
+  onRequest: vi.fn(),
+  start: vi.fn().mockResolvedValue(undefined),
+  stop: vi.fn(),
+  requestConfirmation: vi.fn().mockResolvedValue(true),
+};
+
+const mockPlan: Plan = {
+  id: "plan-test",
+  description: "test plan",
+  steps: [{ description: "run script", scriptId: "list-files", order: 0 }],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(listScripts).mockResolvedValue([]);
+});
+
+describe("DefaultJobExecutor", () => {
+  // 1. execute_script
+  it("execute_script job calls executeFromPlan with the job plan and returns the result", async () => {
+    const expectedResult = { planId: "plan-test", results: [], instructionFile: { planId: "plan-test", steps: [] } };
+    vi.mocked(executeFromPlan).mockResolvedValue(expectedResult);
+
+    const executor = createDefaultJobExecutor(deps);
+    const job = makeJob({ type: "execute_script", plan: mockPlan });
+
+    const result = await executor.execute(job, undefined);
+
+    expect(executeFromPlan).toHaveBeenCalledOnce();
+    expect(executeFromPlan).toHaveBeenCalledWith(mockPlan, deps.scriptsDir, deps.plansDir);
+    expect(result).toBe(expectedResult);
+  });
+
+  // 2. develop_script
+  it("develop_script job calls generateScript with the job goal as capability and returns the result", async () => {
+    const mockScripts = [{ id: "list-files", name: "list-files", description: "lists files", params: [], path: "/tmp/list-files.sh" }];
+    vi.mocked(listScripts).mockResolvedValue(mockScripts);
+
+    const dwResult = { scriptName: "my-script", scriptContent: "#!/bin/bash\n# @name my-script\n# @description does stuff\necho hi" };
+    vi.mocked(generateScript).mockResolvedValue(dwResult);
+
+    const executor = createDefaultJobExecutor(deps);
+    const job = makeJob({ type: "develop_script", goal: "write a script that greets the user" });
+
+    const result = await executor.execute(job, undefined);
+
+    expect(listScripts).toHaveBeenCalledWith(deps.scriptsDir);
+    expect(generateScript).toHaveBeenCalledOnce();
+    expect(generateScript).toHaveBeenCalledWith(
+      mockClient,
+      { capability: job.goal, existingScripts: mockScripts },
+      mockIdentity
+    );
+    expect(result).toBe(dwResult);
+  });
+
+  // 3. plan
+  it("plan job calls createDetailedPlan with the job goal as a work assignment and returns the result", async () => {
+    const lpResult = { plan: mockPlan, missingScripts: [] };
+    vi.mocked(createDetailedPlan).mockResolvedValue(lpResult);
+
+    const executor = createDefaultJobExecutor(deps);
+    const job = makeJob({ type: "plan", goal: "write a detailed plan for the task" });
+
+    const result = await executor.execute(job, undefined);
+
+    expect(createDetailedPlan).toHaveBeenCalledOnce();
+    expect(createDetailedPlan).toHaveBeenCalledWith(
+      mockClient,
+      { id: job.id, description: job.goal },
+      mockIdentity,
+      deps.scriptsDir,
+      deps.plansDir
+    );
+    expect(result).toBe(lpResult);
+  });
+
+  // 4. notify_user
+  it("notify_user job calls adapter.sendResult with the job goal and returns a confirmation", async () => {
+    const executor = createDefaultJobExecutor(deps);
+    const job = makeJob({ type: "notify_user", goal: "Task is complete!" });
+
+    const result = await executor.execute(job, mockAdapter);
+
+    expect(mockAdapter.sendResult).toHaveBeenCalledOnce();
+    expect(mockAdapter.sendResult).toHaveBeenCalledWith(job.goal, "");
+    expect(result).toEqual({ notified: true, message: job.goal });
+  });
+
+  // 5. replan
+  it("replan job calls createStrategicPlan with the job goal and returns the strategic plan", async () => {
+    const strategicPlan = { id: "strategic-test", description: "strategic plan", assignments: [] };
+    vi.mocked(createStrategicPlan).mockResolvedValue(strategicPlan);
+
+    const executor = createDefaultJobExecutor(deps);
+    const job = makeJob({ type: "replan", goal: "replan the overall strategy" });
+
+    const result = await executor.execute(job, undefined);
+
+    expect(createStrategicPlan).toHaveBeenCalledOnce();
+    expect(createStrategicPlan).toHaveBeenCalledWith(
+      mockClient,
+      job.goal,
+      mockIdentity,
+      deps.plansDir
+    );
+    expect(result).toBe(strategicPlan);
+  });
+
+  // 6. initiative_setup
+  it("initiative_setup throws a not-implemented error", async () => {
+    const executor = createDefaultJobExecutor(deps);
+    const job = makeJob({ type: "initiative_setup", goal: "set up the initiative" });
+
+    await expect(executor.execute(job, undefined)).rejects.toThrow("not implemented");
+  });
+
+  // 7. unknown job type
+  it("throws a descriptive error for unknown job types", async () => {
+    const executor = createDefaultJobExecutor(deps);
+    const job = makeJob({ type: "unknown_type" as Job["type"], goal: "do something weird" });
+
+    await expect(executor.execute(job, undefined)).rejects.toThrow('Unknown job type: "unknown_type"');
+  });
+});

--- a/src/jobs/defaultExecutor.ts
+++ b/src/jobs/defaultExecutor.ts
@@ -1,0 +1,74 @@
+import type { JobExecutor } from "./scheduler.js";
+import type { Job } from "./types.js";
+import type { IOAdapter } from "../io/IOAdapter.js";
+import type { LLMClient } from "../agents/claude-client.js";
+import type { IdentityContext, WorkAssignment } from "../types.js";
+import { executeFromPlan } from "../agents/executor.js";
+import { generateScript } from "../agents/developer-writer.js";
+import { createDetailedPlan } from "../agents/lieutenant-planner.js";
+import { createStrategicPlan } from "../agents/planner.js";
+import { listScripts } from "../scripts/index.js";
+
+export interface DefaultJobExecutorDeps {
+  client: LLMClient;
+  identity: IdentityContext;
+  scriptsDir: string;
+  plansDir: string;
+}
+
+export interface DefaultJobExecutor extends JobExecutor {
+  execute(job: Job, adapter: IOAdapter | undefined): Promise<unknown>;
+}
+
+export function createDefaultJobExecutor(
+  deps: DefaultJobExecutorDeps
+): DefaultJobExecutor {
+  const { client, identity, scriptsDir, plansDir } = deps;
+
+  return {
+    async execute(job: Job, adapter: IOAdapter | undefined): Promise<unknown> {
+      switch (job.type) {
+        case "execute_script": {
+          if (!job.plan) {
+            throw new Error(`Job "${job.id}" (execute_script) requires a plan but none was provided`);
+          }
+          return executeFromPlan(job.plan, scriptsDir, plansDir);
+        }
+
+        case "develop_script": {
+          const existingScripts = await listScripts(scriptsDir);
+          return generateScript(
+            client,
+            { capability: job.goal, existingScripts },
+            identity
+          );
+        }
+
+        case "plan": {
+          const assignment: WorkAssignment = {
+            id: job.id,
+            description: job.goal,
+          };
+          return createDetailedPlan(client, assignment, identity, scriptsDir, plansDir);
+        }
+
+        case "notify_user": {
+          await adapter?.sendResult(job.goal, "");
+          return { notified: true, message: job.goal };
+        }
+
+        case "replan": {
+          return createStrategicPlan(client, job.goal, identity, plansDir);
+        }
+
+        case "initiative_setup": {
+          throw new Error("initiative_setup: not implemented (InitiativeBuilder does not exist yet)");
+        }
+
+        default: {
+          throw new Error(`Unknown job type: "${(job as Job).type}"`);
+        }
+      }
+    },
+  };
+}


### PR DESCRIPTION
Creates createDefaultJobExecutor() implementing the JobExecutor interface,
bridging the scheduler to the existing agent pipeline:
- execute_script → executeFromPlan()
- develop_script → generateScript()
- plan → createDetailedPlan()
- notify_user → adapter.sendResult()
- replan → createStrategicPlan()
- initiative_setup → throws not-implemented

Adds 7 unit tests (all mocked) and one integration test validating
scheduler + DefaultJobExecutor + MockLLMClient end-to-end for a plan job.

https://claude.ai/code/session_017uCk3o1xEAV9i1RHp4FgTa