### PR TITLE
docs: mark Job Graph & Scheduler complete, update wiring diagram

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,16 +36,19 @@ Requires `ANTHROPIC_API_KEY` in `.env` (copy `.env.example`).
 
 ### Current Wiring
 ```
-User input → Orchestrator (interprets intent)
-           → General Planner (produces StrategicPlan with WorkAssignments)
-           → Lieutenant Planner (per assignment: detailed Plan with script-level steps)
-             → Developer/Writer (if LP detects missing scripts: generate → review → promote)
-           → Executor (maps plan to instruction JSON)
-           → Compiler (validates + composes + runs scripts)
+User input → Orchestrator (interprets intent, creates job DAG)
+           → Scheduler (dependency resolution, concurrent execution)
+           → DefaultJobExecutor (routes by job type to GP/LP/DW/Executor/Compiler)
+               → General Planner (produces StrategicPlan with WorkAssignments)
+               → Lieutenant Planner (per assignment: detailed Plan with script-level steps)
+                 → Developer/Writer (if LP detects missing scripts: generate → review → promote)
+               → Executor (maps plan to instruction JSON)
+               → Compiler (validates + composes + runs scripts)
+           → Results collected across all jobs
            → Orchestrator (LLM call: interprets results → natural-language response)
            → Response with provenance chain
 ```
-The General Planner partitions work into high-level assignments; the Lieutenant Planner produces script-level execution plans for each. If LP needs scripts that don't exist, Developer/Writer generates them (capped at 3 per invocation). After execution, the Orchestrator makes a final LLM call to synthesize a natural-language response. Multi-assignment plans collect results from all LP → Executor chains.
+The Scheduler is now the execution backbone. The Orchestrator creates a job DAG and hands it to the Scheduler, which resolves dependencies and runs jobs concurrently (default limit 3). `DefaultJobExecutor` dispatches each job type to the appropriate pipeline agent. Fast jobs respond synchronously; slow jobs send an acknowledgement and deliver results async (throbber pattern). Channel routing uses `getChannel()` on `IOAdapter`. Multi-assignment plans collect results from all LP → Executor chains.
 
 **Review chain**: `handleRequest()` reviews the orchestrator's task description and final response using LLM-backed `applyReview()`. `applyReview(content, identity, options?)` uses a `ReviewOptions` object: `{ client?, skipReview?, adapter?, subjectAgentId?, logsDir?, sampling? }`. Calls `reviewWithLLM()` (which passes SOUL.md + CONSTITUTION.md + per-agent anti-patterns to Claude) when an LLMClient is provided; falls back to rule-based `reviewOutput()` on failure. FAFC decisions route through the Human-Judgment Agent (`handleFAFC()`) when an IOAdapter is available; without an adapter, FAFC falls back to halt. The `--no-review` flag bypasses all review. Review decisions are logged to `runtime/logs/review-decisions.jsonl` for RR auditing.
 
@@ -81,14 +84,15 @@ The General Planner partitions work into high-level assignments; the Lieutenant 
 - `src/compiler/compiler.ts` — [*Compiler*](docs/dictionary.md): validates instruction JSON, optional semantic review gate, runs scripts
 - `src/scripts/runner.ts` — Shell script execution with timeout (internal to *Compiler*)
 - `src/scripts/index.ts` — [*Script*](docs/dictionary.md) discovery via `@name`/`@description`/`@param` frontmatter
-- `src/io/IOAdapter.ts` — `IOAdapter` interface for messaging abstraction
+- `src/io/IOAdapter.ts` — `IOAdapter` interface for messaging abstraction; `getChannel()` returns the active channel for job routing
 - `src/io/CLIAdapter.ts` — `createCLIAdapter()` CLI implementation of IOAdapter
 - `src/io/TestAdapter.ts` — `TestAdapter` IOAdapter for tests: collects all output into inspectable arrays, configurable `requestConfirmation()`
 - `src/test-utils/MockLLMClient.ts` — `MockLLMClient` pattern-matched mock LLM client for integration tests; configurable per-agent responses
 - `src/integration/pipeline.integration.test.ts` — 5 smoke tests exercising the full Orch → GP → LP → Executor → Compiler pipeline
 - `src/jobs/types.ts` — `Job`, `JobType`, `JobStatus`, `Callback`, `StatementRef` types
 - `src/jobs/store.ts` — `createJobStore()` persistent job store in `runtime/jobs/`
-- `src/jobs/scheduler.ts` — `createScheduler()` DAG scheduler with dependency resolution
+- `src/jobs/scheduler.ts` — `createScheduler()` DAG scheduler with dependency resolution, concurrent execution (default limit 3), callbacks
+- `src/jobs/defaultExecutor.ts` — `createDefaultJobExecutor()`, routes job types to pipeline agents (GP, LP, DW, Executor, Compiler)
 - `src/logger.ts` — `setVerbose()`, `isVerbose()`, `verbose()` logging utilities
 - `src/sessions.ts` — `loadSession()`/`saveSession()` for persisting conversation history to `runtime/sessions/`
 

--- a/docs/planning/Roadmap.md
+++ b/docs/planning/Roadmap.md
@@ -37,7 +37,7 @@ See `CLAUDE.md` for the full source file map.
 | Identity Writer (atomic config writes + backups) | Built — Phase 3 Tier 3 (completed 2026-02-25) |
 | Pre-Execution Semantic Review (stubbed gate) | Built — Phase 3 Tier 3 (completed 2026-02-25) |
 | Integration Test Harness (`TestAdapter`, `MockLLMClient`, 5 smoke tests) | Built — Phase 3 Tier 3 (completed 2026-03-11) |
-| Job Graph & Scheduler | Partial — types, store, scheduler core built (2026-02-25); orchestrator refactor + DefaultJobExecutor pending |
+| Job Graph & Scheduler | Built — Phase 3 Tier 4 (completed 2026-03-20) |
 | Initiative system | Phase 3 — Tier 4 |
 | USER.md | Phase 3 — Tier 6 |
 | Adjutant | Phase 3 — Tier 5 |
@@ -154,7 +154,7 @@ These require the full Phase 2 review chain before they're safe to build. Develo
 
 *Tier 4 is the architectural transition point: the linear GP → LP → Executor pipeline is replaced by job-based dispatch. After Tier 4, all execution routes through the Job Graph.*
 
-- **(11)** **Job Graph & Scheduler** `[ ]`: `src/jobs/` — Job types (`execute_script`, `develop_script`, `plan`, `notify_user`, `replan`, `initiative_setup`). Monotonic IDs for cycle prevention. Persistent store in `runtime/jobs/`. DAG scheduler with dependency resolution, concurrent execution (default limit 3), callbacks. Orchestrator refactored to job-based dispatch with backward compat. Throbber/ack pattern: configurable timeout per job type, synchronous UX for fast jobs, async follow-up for slow ones. See [JobGraph.md](../architecture/JobGraph.md) for the architecture spec.
+- **(11)** **Job Graph & Scheduler** `[x]` (completed 2026-03-20): `src/jobs/` — Job types (`execute_script`, `develop_script`, `plan`, `notify_user`, `replan`, `initiative_setup`). Monotonic IDs for cycle prevention. Persistent store in `runtime/jobs/`. DAG scheduler with dependency resolution, concurrent execution (default limit 3), callbacks. Orchestrator refactored to job-based dispatch; `DefaultJobExecutor` routes job types to GP/LP/DW/Executor/Compiler. Throbber/ack pattern: configurable timeout per job type, synchronous UX for fast jobs, async follow-up for slow ones. Channel routing via `IOAdapter.getChannel()`. See [JobGraph.md](../architecture/JobGraph.md) for the architecture spec.
 - **(12)** **User Statement Log** *(Backlog)* `[ ]`: `src/statements/` — append-only log in `runtime/statements/`. N:N evidence join between jobs and statements. Supersession lifecycle. Wired into Orchestrator for statement extraction. See [`backlog-statement-log.md`](backlog/backlog-statement-log.md).
 - **(13)** **Initiative Table & Persistence** *(Backlog)* `[ ]`: `src/initiatives/` — persistent table in `runtime/initiatives/`. Cron expressions, architecture types, stop conditions. Separate from job store. See [`backlog-initiative-table.md`](backlog/backlog-initiative-table.md).
 - **(14)** **Initiative system** `[ ]`: InitiativeBuilder agent registered in `registry.json`. LLM determines initiative parameters from Orchestrator-identified patterns. Non-Static architectures route through HJA. Cron trigger stub (checked per orchestrator tick, not system cron). See [OpenQuestions.md §Initiatives](OpenQuestions.md#initiatives).


### PR DESCRIPTION
- Roadmap: mark item (11) [x] (completed 2026-03-20), remove "orchestrator
  refactor + DefaultJobExecutor pending" note from both table and detail entry
- CLAUDE.md Current Wiring: replace linear GP→LP→Executor description with
  scheduler-as-backbone flow (Orchestrator → Scheduler → DefaultJobExecutor →
  pipeline agents); note throbber pattern and getChannel() for channel routing
- CLAUDE.md Key Source Files: add src/jobs/defaultExecutor.ts entry; expand
  scheduler.ts description; note getChannel() on IOAdapter

https://claude.ai/code/session_015t5em7BLi6qHrAtfdSvTmP