### PR TITLE
fix: replace aspirational workflow commands with actual ones in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,13 +137,9 @@ Every new feature that touches the pipeline requires an integration test in `src
 ## Workflow Commands
 
 Custom slash commands in `.claude/commands/`:
-- `/create-prd` — Generate a PRD from a feature description (asks clarifying questions first)
-- `/generate-tasks` — Generate a task list from a PRD (two-phase: parent tasks → sub-tasks with user approval)
-- `/process-task-list` — Work through a task list one sub-task at a time, committing after each parent task completes
-- `/fold-in` — Apply queued changes from `docs/working/fold-me-in.md` into architecture and planning docs, then run a consistency review
-- `/reconcile-docs` — Code-first documentation reconciliation pass; updates docs to match source tree
-
-When starting a new feature, the workflow is: `/create-prd` → `/generate-tasks` → `/process-task-list`.
+- `/rectify` — Scan for inconsistencies between the documentation and the actual codebase, then print a summary report
+- `/summarize` — Produce a development summary covering the current state of the repository (recent PRs, open issues, build status, etc.)
+- `/state-of-system` — Generate `docs/STATE_OF_SYSTEM.md` by inspecting the actual codebase directly
 
 ## Documentation Conventions
 


### PR DESCRIPTION
The Workflow Commands section listed five commands that don't exist
(/create-prd, /generate-tasks, /process-task-list, /fold-in,
/reconcile-docs). Replace with the three commands that actually exist in
.claude/commands/: /rectify, /summarize, /state-of-system.

https://claude.ai/code/session_01MMZcvc8pTJrFDVgksYXzs4