### PR TITLE
Add per-agent Ollama model overrides via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,13 @@ ANTHROPIC_API_KEY=sk-ant-...
 # OLLAMA_BASE_URL=http://localhost:11434
 # OLLAMA_MODEL=llama3.2
 
+# Per-agent Ollama model overrides (optional, fall back to OLLAMA_MODEL)
+# OLLAMA_MODEL_ORCHESTRATOR=llama3.1:8b
+# OLLAMA_MODEL_PLANNER=qwen2.5-coder:7b-instruct
+# OLLAMA_MODEL_LIEUTENANT_PLANNER=qwen2.5-coder:7b-instruct
+# OLLAMA_MODEL_EXECUTOR=qwen2.5-coder:7b-instruct
+# OLLAMA_MODEL_DEVELOPER_WRITER=qwen2.5-coder:7b-instruct
+# OLLAMA_MODEL_REVIEWER=llama3.1:8b
+
 # Optional: use real LLM calls in integration tests (tests 1-3 only)
 # USE_REAL_LLM=1

--- a/src/agents/base.ts
+++ b/src/agents/base.ts
@@ -9,7 +9,7 @@ export async function invokeAgent(
   identity: IdentityContext
 ): Promise<AgentOutput> {
   const systemPrompt = buildSystemPrompt(agentConfig, identity);
-  const response = await client.sendMessage(systemPrompt, input);
+  const response = await client.sendMessage(systemPrompt, input, agentConfig.id);
 
   return {
     content: response.content,

--- a/src/agents/big-brother.ts
+++ b/src/agents/big-brother.ts
@@ -67,6 +67,7 @@ export async function proposeConfigUpdate(
 
   const result = await callWithValidation(client, systemPrompt, userMessage, BBOutputSchema, {
     label: "BIG_BROTHER",
+    agentId: "big-brother",
   });
 
   verbose("BB: proposal ready", { changeRationale: result.changeRationale });

--- a/src/agents/claude-client.ts
+++ b/src/agents/claude-client.ts
@@ -14,12 +14,14 @@ export interface ClaudeResponse {
 export interface LLMClient {
   sendMessage(
     systemPrompt: string,
-    userMessage: string
+    userMessage: string,
+    agentId?: string
   ): Promise<ClaudeResponse>;
 
   sendMessages(
     systemPrompt: string,
-    messages: MessageParam[]
+    messages: MessageParam[],
+    agentId?: string
   ): Promise<ClaudeResponse>;
 }
 
@@ -47,7 +49,8 @@ export function createClaudeClient(apiKey?: string): LLMClient {
   return {
     async sendMessage(
       systemPrompt: string,
-      userMessage: string
+      userMessage: string,
+      _agentId?: string
     ): Promise<ClaudeResponse> {
       const model = getClaudeModel();
       verbose("Claude API: sendMessage", { model, systemPromptLength: systemPrompt.length, userMessage });
@@ -64,7 +67,8 @@ export function createClaudeClient(apiKey?: string): LLMClient {
 
     async sendMessages(
       systemPrompt: string,
-      messages: MessageParam[]
+      messages: MessageParam[],
+      _agentId?: string
     ): Promise<ClaudeResponse> {
       const model = getClaudeModel();
       verbose("Claude API: sendMessages", { model, systemPromptLength: systemPrompt.length, messageCount: messages.length });

--- a/src/agents/developer-writer.ts
+++ b/src/agents/developer-writer.ts
@@ -45,7 +45,7 @@ Respond with ONLY a JSON object, no fences, no prose:
     systemPrompt,
     userMessage,
     DeveloperWriterResultSchema,
-    { label: "DeveloperWriter" }
+    { label: "DeveloperWriter", agentId: "developer-writer" }
   );
 
   // Validate that the generated script has proper frontmatter

--- a/src/agents/lieutenant-planner.ts
+++ b/src/agents/lieutenant-planner.ts
@@ -74,6 +74,7 @@ Rules:
 
   const plan = await callWithValidation(client, systemPrompt, userMessage, PlanSchema, {
     label: "LieutenantPlanner",
+    agentId: "lieutenant-planner",
   });
 
   verbose("LieutenantPlanner: validated plan", plan);

--- a/src/agents/llm-reviewer.ts
+++ b/src/agents/llm-reviewer.ts
@@ -66,6 +66,7 @@ Does this output violate any security constraints, ethical guidelines, or the sy
     verbose("LLM reviewer: sending review request", { subjectAgentId, contentLength: content.length });
     const result = await callWithValidation(client, systemPrompt, userMessage, ReviewerResponseSchema, {
       label: "LLM reviewer",
+      agentId: "reviewer",
     });
 
     verbose("LLM reviewer: decision", { decision: result.decision, reasoning: result.reasoning });

--- a/src/agents/llm-utils.ts
+++ b/src/agents/llm-utils.ts
@@ -18,6 +18,7 @@ export function extractJson(text: string): string {
 export interface CallWithValidationOptions {
   maxRetries?: number;
   label?: string;
+  agentId?: string;
 }
 
 /**
@@ -34,7 +35,7 @@ export async function callWithValidation<T>(
   schema: ZodSchema<T>,
   options: CallWithValidationOptions = {}
 ): Promise<T> {
-  const { maxRetries = 2, label = "LLM call" } = options;
+  const { maxRetries = 2, label = "LLM call", agentId } = options;
   const totalAttempts = maxRetries + 1;
 
   let lastError: Error | undefined;
@@ -43,7 +44,7 @@ export async function callWithValidation<T>(
   for (let attempt = 1; attempt <= totalAttempts; attempt++) {
     try {
       verbose(`${label}: attempt ${attempt}/${totalAttempts}`);
-      const response = await client.sendMessage(systemPrompt, currentMessage);
+      const response = await client.sendMessage(systemPrompt, currentMessage, agentId);
       const jsonStr = extractJson(response.content);
       const parsed = JSON.parse(jsonStr);
       return schema.parse(parsed);

--- a/src/agents/ollama-client.test.ts
+++ b/src/agents/ollama-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { createOllamaClient } from "./ollama-client.js";
+import { createOllamaClient, resolveOllamaModel } from "./ollama-client.js";
 
 function makeFetch(status: number, body: unknown) {
   return vi.fn().mockResolvedValue({
@@ -12,6 +12,27 @@ function makeFetch(status: number, body: unknown) {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+});
+
+describe("resolveOllamaModel", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns per-agent env var when set", () => {
+    vi.stubEnv("OLLAMA_MODEL_ORCHESTRATOR", "llama3.1:8b");
+    vi.stubEnv("OLLAMA_MODEL", "llama3.2");
+    expect(resolveOllamaModel("orchestrator")).toBe("llama3.1:8b");
+  });
+
+  it("falls back to OLLAMA_MODEL when per-agent var is not set", () => {
+    vi.stubEnv("OLLAMA_MODEL", "mistral");
+    expect(resolveOllamaModel("orchestrator")).toBe("mistral");
+  });
+
+  it("falls back to hardcoded default when neither env var is set", () => {
+    expect(resolveOllamaModel("orchestrator")).toBe("llama3.2");
+  });
 });
 
 describe("createOllamaClient", () => {

--- a/src/agents/ollama-client.ts
+++ b/src/agents/ollama-client.ts
@@ -3,11 +3,26 @@ import { verbose } from "../logger.js";
 
 type OllamaMessage = { role: string; content: string };
 
+const DEFAULT_OLLAMA_MODEL = "llama3.2";
+
+/**
+ * Resolve the Ollama model for a given agent ID.
+ * Resolution order: per-agent env var → OLLAMA_MODEL → hardcoded default.
+ */
+export function resolveOllamaModel(agentId?: string): string {
+  if (agentId) {
+    const key = `OLLAMA_MODEL_${agentId.toUpperCase().replace(/-/g, "_")}`;
+    const perAgent = process.env[key];
+    if (perAgent) return perAgent;
+  }
+  return process.env.OLLAMA_MODEL ?? DEFAULT_OLLAMA_MODEL;
+}
+
 export function createOllamaClient(baseUrl?: string, model?: string): LLMClient {
   const url = baseUrl ?? process.env.OLLAMA_BASE_URL ?? "http://localhost:11434";
-  const mdl = model ?? process.env.OLLAMA_MODEL ?? "llama3.2";
 
-  async function call(messages: OllamaMessage[]): Promise<ClaudeResponse> {
+  async function call(messages: OllamaMessage[], agentId?: string): Promise<ClaudeResponse> {
+    const mdl = model ?? resolveOllamaModel(agentId);
     const endpoint = `${url}/api/chat`;
     const body = { model: mdl, messages, stream: false };
     verbose("Ollama: request", { endpoint, model: mdl, messageCount: messages.length, messages });
@@ -48,14 +63,14 @@ export function createOllamaClient(baseUrl?: string, model?: string): LLMClient 
   }
 
   return {
-    sendMessage(systemPrompt: string, userMessage: string): Promise<ClaudeResponse> {
+    sendMessage(systemPrompt: string, userMessage: string, agentId?: string): Promise<ClaudeResponse> {
       return call([
         { role: "system", content: systemPrompt },
         { role: "user", content: userMessage },
-      ]);
+      ], agentId);
     },
 
-    sendMessages(systemPrompt: string, messages: MessageParam[]): Promise<ClaudeResponse> {
+    sendMessages(systemPrompt: string, messages: MessageParam[], agentId?: string): Promise<ClaudeResponse> {
       const mapped: OllamaMessage[] = messages.map((m) => ({
         role: m.role as string,
         content:
@@ -66,7 +81,7 @@ export function createOllamaClient(baseUrl?: string, model?: string): LLMClient 
                 .map((b) => (b as { type: "text"; text: string }).text)
                 .join(""),
       }));
-      return call([{ role: "system", content: systemPrompt }, ...mapped]);
+      return call([{ role: "system", content: systemPrompt }, ...mapped], agentId);
     },
   };
 }

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -122,8 +122,8 @@ export async function handleRequest(
     ? await client.sendMessages(systemPrompt, [
         ...history,
         { role: "user", content: currentMessage },
-      ])
-    : await client.sendMessage(systemPrompt, currentMessage);
+      ], "orchestrator")
+    : await client.sendMessage(systemPrompt, currentMessage, "orchestrator");
 
   const taskDescription = interpretResponse.content.trim();
   verbose("Orchestrator: task description", taskDescription);
@@ -318,7 +318,7 @@ export async function handleRequest(
     allResults
   );
   verbose("Orchestrator: sending response-generation request", { responsePrompt });
-  const responseContent = await client.sendMessage(systemPrompt, responsePrompt);
+  const responseContent = await client.sendMessage(systemPrompt, responsePrompt, "orchestrator");
   const response = responseContent.content.trim();
   verbose("Orchestrator: response generated", { response });
 

--- a/src/agents/planner.ts
+++ b/src/agents/planner.ts
@@ -56,6 +56,7 @@ Rules:
 
   const plan = await callWithValidation(client, systemPrompt, userMessage, PlanSchema, {
     label: "Planner",
+    agentId: "planner",
   });
 
   verbose("Planner: validated plan", plan);
@@ -98,6 +99,7 @@ Rules:
 
   const plan = await callWithValidation(client, systemPrompt, userMessage, StrategicPlanSchema, {
     label: "GeneralPlanner",
+    agentId: "planner",
   });
 
   verbose("GeneralPlanner: validated strategic plan", plan);

--- a/src/agents/reviewer-reviewer.ts
+++ b/src/agents/reviewer-reviewer.ts
@@ -63,6 +63,7 @@ export async function auditReviewDecision(
 
   const result = await callWithValidation(client, systemPrompt, userMessage, RROutputSchema, {
     label: "Reviewer-Reviewer",
+    agentId: "reviewer-reviewer",
   });
 
   verbose("RR: audit result", {

--- a/src/integration/pipeline.integration.test.ts
+++ b/src/integration/pipeline.integration.test.ts
@@ -842,3 +842,50 @@ describe("11. Provenance Chain with Job IDs", () => {
     30_000
   );
 });
+
+// ---------------------------------------------------------------------------
+// Test 12 — Per-Agent ID Wiring  (mock-only)
+//
+// Validates: agentId is threaded through to sendMessage/sendMessages so that
+// Ollama model selection can vary per agent. Asserts the orchestrator's LLM
+// calls carry the correct agentId.
+// ---------------------------------------------------------------------------
+
+describe("12. Per-Agent ID Wiring", () => {
+  it.skipIf(USE_REAL_LLM)(
+    "passes agentId to sendMessage for orchestrator calls",
+    async () => {
+      const plansDir = await makeTmpPlansDir();
+
+      try {
+        const client = createMockLLMClient();
+        const adapter = createTestAdapter();
+
+        await handleRequest(
+          client,
+          "Hello, who are you?",
+          identity,
+          INSTANCE_SCRIPTS_DIR,
+          plansDir,
+          undefined,
+          /* skipReview */ true,
+          adapter
+        );
+
+        // Orchestrator calls sendMessage with agentId "orchestrator"
+        expect(client.agentIdLog).toContain("orchestrator");
+
+        // All logged agentIds should be defined strings (no undefined from the pipeline agents)
+        const definedIds = client.agentIdLog.filter((id) => id !== undefined);
+        expect(definedIds.length).toBeGreaterThan(0);
+        for (const id of definedIds) {
+          expect(typeof id).toBe("string");
+          expect((id as string).length).toBeGreaterThan(0);
+        }
+      } finally {
+        await rm(plansDir, { recursive: true, force: true });
+      }
+    },
+    30_000
+  );
+});

--- a/src/test-utils/MockLLMClient.ts
+++ b/src/test-utils/MockLLMClient.ts
@@ -35,6 +35,8 @@ export interface MockLLMOptions {
 export interface MockLLMClient extends LLMClient {
   /** Ordered log of detected call types, for test assertions. */
   callLog: string[];
+  /** Log of agentId values passed to sendMessage/sendMessages, in call order. */
+  agentIdLog: (string | undefined)[];
 }
 
 function ok(content: string): ClaudeResponse {
@@ -105,11 +107,13 @@ const DEFAULT_REVIEWER_ALLOW = JSON.stringify({
 
 export function createMockLLMClient(options: MockLLMOptions = {}): MockLLMClient {
   const callLog: string[] = [];
+  const agentIdLog: (string | undefined)[] = [];
   let lpCallCount = 0;
 
   const reviewerResponse = options.reviewerDecision ?? DEFAULT_REVIEWER_ALLOW;
 
-  async function sendMessage(systemPrompt: string, userMessage: string): Promise<ClaudeResponse> {
+  async function sendMessage(systemPrompt: string, userMessage: string, agentId?: string): Promise<ClaudeResponse> {
+    agentIdLog.push(agentId);
     // LLM reviewer: system prompt begins with the reviewer preamble
     if (systemPrompt.includes("You are the security and ethics reviewer")) {
       callLog.push("reviewer");
@@ -166,7 +170,8 @@ export function createMockLLMClient(options: MockLLMOptions = {}): MockLLMClient
 
   async function sendMessages(
     systemPrompt: string,
-    messages: MessageParam[]
+    messages: MessageParam[],
+    agentId?: string
   ): Promise<ClaudeResponse> {
     const last = messages[messages.length - 1];
     let content = "";
@@ -178,8 +183,8 @@ export function createMockLLMClient(options: MockLLMOptions = {}): MockLLMClient
         .map((b) => ("text" in b ? b.text : ""))
         .join("");
     }
-    return sendMessage(systemPrompt, content);
+    return sendMessage(systemPrompt, content, agentId);
   }
 
-  return { callLog, sendMessage, sendMessages };
+  return { callLog, agentIdLog, sendMessage, sendMessages };
 }


### PR DESCRIPTION
Implements OLLAMA_MODEL_{AGENT_ID} env var support so each pipeline agent
can target a different locally-hosted model. Adds resolveOllamaModel() as
the single source of truth for model selection, threads agentId through the
LLMClient interface (optional, ignored by Anthropic provider), and wires
the agent ID at every sendMessage/sendMessages call site.

- src/agents/ollama-client.ts: add resolveOllamaModel(agentId?) with
  per-agent → global → hardcoded fallback chain; update call() to resolve
  model per-call when no explicit model arg was given
- src/agents/claude-client.ts: add optional agentId param to LLMClient
  interface and Anthropic client methods (accepted, ignored)
- src/agents/base.ts: pass agentConfig.id to sendMessage via invokeAgent
- src/agents/llm-utils.ts: add agentId to CallWithValidationOptions and
  thread it through to sendMessage
- All pipeline agents (orchestrator, planner, lieutenant-planner,
  developer-writer, llm-reviewer, reviewer-reviewer, big-brother): pass
  agent ID via callWithValidation options or direct sendMessage calls
- src/test-utils/MockLLMClient.ts: capture agentId in new agentIdLog[]
- src/integration/pipeline.integration.test.ts: Test 12 asserts agentId
  is threaded through to the orchestrator's LLM calls
- .env.example: document per-agent override vars with examples

All 235 unit tests and 16 integration tests pass.

https://claude.ai/code/session_01Wyg3oAHVouvVzygXKMMY2Q