### PR TITLE
docs: replace gh CLI with GitHub API instructions

### DIFF
--- a/.claude/commands/rectify.md
+++ b/.claude/commands/rectify.md
@@ -1,6 +1,6 @@
 Scan for inconsistencies between the documentation and the actual codebase. Work through each check below, then print a summary report of all findings.
 
-Do NOT create GitHub Issues during this run — just report findings. (The `gh` CLI does not work in this environment; use the GitHub API directly with `GH_TOKEN` if issue creation is ever needed: `curl -X POST -H "Authorization: token $GH_TOKEN" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/hikusukih/writ/issues -d '{"title":"...","body":"..."}'`)
+Do NOT create GitHub Issues during this run — just report findings.
 
 ---
 

--- a/.claude/commands/summarize.md
+++ b/.claude/commands/summarize.md
@@ -14,7 +14,7 @@ List each branch. For branches starting with `claude/`, note the task descriptio
 
 ## 3. Current GitHub Issues by label
 
-The `gh` CLI does not work in this environment because the git remote points to a local proxy. Use the GitHub API directly with `GH_TOKEN`:
+The `gh` CLI does not work in this environment. Use the GitHub API directly with `GH_TOKEN` (see CLAUDE.md § GitHub API Access):
 
 ```bash
 curl -s -H "Authorization: token $GH_TOKEN" -H "Accept: application/vnd.github.v3+json" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,25 @@ Requires `ANTHROPIC_API_KEY` in `.env` (copy `.env.example`).
 
 **Provider switching**: Set `LLM_PROVIDER=ollama` in `.env` to use a locally-hosted model instead of the Anthropic API. Useful for dev/smoke testing to reduce API costs. Set `OLLAMA_BASE_URL` and `OLLAMA_MODEL` as needed (defaults: `http://localhost:11434` and configurable model).
 
+## GitHub API Access
+
+The `gh` CLI does not work in this environment — the git remote points to a local proxy that `gh` does not recognize as a GitHub host. Use the GitHub API directly with `GH_TOKEN`:
+
+```bash
+# List issues by label
+curl -s -H "Authorization: token $GH_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/hikusukih/writ/issues?state=open&labels=on-deck&per_page=50"
+
+# Create an issue
+curl -s -X POST -H "Authorization: token $GH_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/hikusukih/writ/issues" \
+  -d '{"title":"...","body":"...","labels":["..."]}'
+```
+
+If `GH_TOKEN` is unset, GitHub operations are unavailable — note it and skip rather than failing.
+
 ## Architecture
 
 ### Current Wiring


### PR DESCRIPTION
gh CLI does not work because the git remote points to a local proxy
that gh doesn't recognize as a GitHub host. GH_TOKEN + direct API
calls work correctly (confirmed by creating issue #30).

Updated summarize.md and rectify.md to use curl with GH_TOKEN instead.