### PR TITLE
Add destructive action safeguards to CLAUDE.md, CONSTITUTION.md, and compiler anti-patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,14 @@ The Scheduler is the execution backbone. The Orchestrator calls the General Plan
 ### Project Tooling
 - `scripts/` — Dev/CI scripts (export-for-claude.sh). Not used by the running instance.
 
+## Destructive Action Safeguards
+
+Before any command that deletes, overwrites, or bulk-replaces files outside `runtime/`, confirm the target list and get explicit user approval. This includes but is not limited to: `rm -rf`, `git push --force`, bulk file moves/renames, and any operation that would overwrite source files or identity files.
+
+When a task involves removing or replacing existing content, list what will be affected before acting. Err on the side of asking.
+
+Never delete or overwrite files under `src/instance/identity/` without FAFC-style confirmation — these are the system's core identity and values.
+
 ## Code Patterns
 
 - **Functional style**: Export functions, not classes. `LLMClient` is an interface for mockability.

--- a/src/instance/identity/CONSTITUTION.md
+++ b/src/instance/identity/CONSTITUTION.md
@@ -22,3 +22,6 @@ Never expose API keys, tokens, passwords, or other secrets in outputs, logs, or 
 
 ### Pro-Social Orientation
 Produce content and take actions that promote constructive discourse. Encourage good-faith communication. When creating public-facing content, aim to be constructive and collaborative.
+
+### Destructive Actions Demand Elevated Scrutiny
+Any action that deletes, overwrites, or irreversibly modifies external resources is high-stakes by default. Before executing destructive operations — especially bulk operations — verify targets against known expectations and seek human confirmation (FAFC). When uncertain whether an action is destructive, treat it as destructive.

--- a/src/instance/identity/anti-patterns/anti-patterns-compiler.md
+++ b/src/instance/identity/anti-patterns/anti-patterns-compiler.md
@@ -1,0 +1,6 @@
+# Anti-Patterns: Compiler
+
+<!-- Append-only log of known anti-patterns for the Compiler agent.
+     Populated by BIG_BROTHER (Tier 3). Do not manually edit entries once added. -->
+
+**Bulk destructive operations without confirmation**: Executing scripts that delete, overwrite, or irreversibly modify multiple files or external resources without routing through FAFC first. Single-target destructive actions require reviewer scrutiny; bulk destructive actions require human confirmation regardless of sampling rate.


### PR DESCRIPTION
Encodes destructive-action safeguards at both build-time (CLAUDE.md) and runtime
(CONSTITUTION.md + compiler anti-pattern) layers:

- CLAUDE.md: New "Destructive Action Safeguards" section requiring explicit user approval
  before rm -rf, force-push, bulk overwrites, or any modification to src/instance/identity/.
- CONSTITUTION.md: New "Destructive Actions Demand Elevated Scrutiny" principle making
  FAFC confirmation mandatory for bulk destructive ops; picked up automatically by LLM reviewer.
- anti-patterns-compiler.md: Created with the bulk-destructive-ops anti-pattern so the
  reviewer has a concrete, agent-specific check at the Compiler layer.

https://claude.ai/code/session_013R8juYhU795msvWjKicyyp