### PR TITLE
feat: convert /state-of-system to conversational output

### DIFF
--- a/.claude/commands/state-of-system.md
+++ b/.claude/commands/state-of-system.md
@@ -1,6 +1,6 @@
-Generate `docs/STATE_OF_SYSTEM.md` by inspecting the actual codebase. Do NOT copy from other docs — derive everything by reading source files directly. Regenerate from scratch each time (overwrite the file completely).
+Inspect the actual codebase and generate a State of System report as conversational output. Do NOT copy from other docs — derive everything by reading source files directly. Do NOT write to any file.
 
-Work through each section below, then write the full file.
+Work through each section below, then print the full report in the conversation.
 
 ---
 
@@ -65,7 +65,7 @@ List items where: the roadmap says `[ ]` (not done) AND there is no correspondin
 
 ## Output
 
-Write the complete file to `docs/STATE_OF_SYSTEM.md` with this structure:
+Print the complete report to the conversation with this structure:
 
 ```markdown
 # State of System
@@ -90,5 +90,3 @@ _Generated: <today's date>. Reflects actual codebase — not aspirational docs._
 ## Known Gaps
 ...
 ```
-
-Confirm after writing: "STATE_OF_SYSTEM.md written."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ Every new feature that touches the pipeline requires an integration test in `src
 Custom slash commands in `.claude/commands/`:
 - `/rectify` — Scan for inconsistencies between the documentation and the actual codebase, then print a summary report
 - `/summarize` — Produce a development summary covering the current state of the repository (recent PRs, open issues, build status, etc.)
-- `/state-of-system` — Generate `docs/STATE_OF_SYSTEM.md` by inspecting the actual codebase directly
+- `/state-of-system` — Inspect the actual codebase and print a State of System report to the conversation
 
 ## Documentation Conventions
 


### PR DESCRIPTION
Change the /state-of-system command to print the report to the
conversation instead of writing to docs/STATE_OF_SYSTEM.md. Update
CLAUDE.md to reflect the new behavior.

https://claude.ai/code/session_01WaTMywqq5DQtiz9Wc1CzR9