### PR TITLE
docs: record gist command channel decisions and update planning docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,15 @@ Never delete or overwrite files under `src/instance/identity/` without FAFC-styl
 - **Zod validation**: All JSON read from disk or parsed from Claude responses validated with Zod schemas.
 - **Tests alongside source**: `foo.ts` → `foo.test.ts` in same directory. Vitest with mocked Claude client.
 - **Integration tests**: `src/integration/*.integration.test.ts` — run via `npm run test:integration`. Use `TestAdapter` (`src/io/TestAdapter.ts`) + `MockLLMClient` (`src/test-utils/MockLLMClient.ts`) for full pipeline coverage. Tests import functions directly — no process spawning, no readline, no `CLIAdapter`. `npm test` excludes these; `npm run test:all` includes both. **When implementing a new feature, add or extend an integration test in `src/integration/pipeline.integration.test.ts` to cover the happy path through the full pipeline.**
-- **Script frontmatter**: Shell scripts use `# @name`, `# @description`, `# @param` comment headers for discovery.
+- **Script frontmatter**: Shell scripts use comment-based frontmatter for discovery by `listScripts()` (`src/scripts/index.ts`). Headers must appear at the top of the file before any non-comment line — parsing stops at the first line that doesn't start with `#`. Pattern:
+  ```bash
+  #!/bin/bash
+  # @name my-script
+  # @description One-line description of what this script does
+  # @param PARAM_ONE First parameter (required)
+  # @param PARAM_TWO Second parameter (optional)
+  ```
+  `@name` sets the script ID used in instruction JSON. `@description` is surfaced to the LLM for script selection. Each `@param` names an environment variable the script expects; list them in the order they appear in the script. Scripts without valid frontmatter are silently skipped.
 
 ## Integration Test Requirements
 

--- a/docs/decisions/0001-gist-command-channel.md
+++ b/docs/decisions/0001-gist-command-channel.md
@@ -1,0 +1,56 @@
+# ADR-0001: Gist-Based Command Channel for Live Instance
+
+## Status
+Accepted
+
+## Context
+The live deployed instance of Writ needs a way to receive commands from the operator without requiring an inbound network connection. The instance runs in an environment where exposing a port is undesirable or impractical, and the operator may need to send commands from a mobile device (phone). A pull-based channel is strongly preferred over push-based.
+
+## Options Considered
+
+| Option | Verdict | Reason |
+|---|---|---|
+| Exposed API endpoint | Rejected | Requires inbound ports; complicates deployment and security posture |
+| File committed to GitHub repo | Rejected | Public visibility; pollutes commit history; awkward to overwrite |
+| Google Docs | Rejected | Auth complexity; requires OAuth setup on the instance side |
+| Private GitHub Gist | **Chosen** | Private, pull-based, no inbound ports, phone-writable via GitHub UI |
+
+## Decision
+
+Use a **private GitHub Gist** as the command channel for the live instance.
+
+### Command format
+
+Commands are plaintext, interpreted by the LLM pipeline. The operator writes to the Gist as if composing an email to the system — no special syntax required.
+
+### Inbox pattern (filesystem dead drop)
+
+The polling script fetches the Gist and writes its content to a local inbox file (e.g., `runtime/inbox/gist.txt`). This decouples polling from processing:
+
+- The polling script is dumb infrastructure — fetch, write, done.
+- Multiple components can write to the inbox (future: other input channels).
+- LLM interpretation happens downstream in the pipeline, not in the poll script.
+
+### Bootstrap cron
+
+Initial scheduling is a temporary external cron (e.g., system crontab). This is a bootstrap measure only. Writ should self-schedule polling as one of its first self-management tasks once operational.
+
+### Runtime directory
+
+All runtime-generated files (inbox, logs, state) live in `runtime/` at the project root, which is gitignored. The inbox path is `runtime/inbox/`.
+
+### Single-command-per-poll limitation
+
+The Gist holds one command at a time. If the operator overwrites the Gist before the next poll, the earlier command is lost. This is **accepted** for MVP cadence (hourly polling). The operator is expected to treat the Gist as a single-slot inbox.
+
+## Rationale
+
+A pull-based channel with no inbound ports is the most deployment-friendly option for a self-hosted agent. Private Gists are accessible from any device with a GitHub account, require no additional infrastructure, and can be fetched with a simple `curl` + `GH_TOKEN`. The inbox/dead-drop pattern keeps the polling script minimal and makes the processing path testable independently.
+
+## Consequences
+
+- Polling script must be implemented and scheduled externally at bootstrap.
+- `GH_TOKEN` with Gist read permission must be available to the instance at runtime.
+- `runtime/inbox/` directory must be created before polling begins.
+- Future IOAdapter integration will consume from the inbox path rather than from stdin.
+- If multi-source input is desired later, the inbox pattern accommodates it without changes to the processing pipeline — see backlog item `backlog-multi-source-input.md`.

--- a/docs/planning/Roadmap.md
+++ b/docs/planning/Roadmap.md
@@ -165,6 +165,8 @@ These require the full Phase 2 review chain before they're safe to build. Develo
 
 *Tier 5 — Infrastructure + Deployment: containerize before Adjutant — the Adjutant will install software and reach outside the system, which should happen inside a container.*
 
+- **Gist-based command channel** *(In progress)*: Private GitHub Gist as pull-based command channel for the live instance. Poll script fetches Gist and writes to `runtime/inbox/` (filesystem dead drop). IOAdapter integration pending. Bootstrap cron documented; Writ should self-schedule polling as an early self-management task. See [ADR-0001](../decisions/0001-gist-command-channel.md).
+
 - **(15)** **Containerization** *(Backlog)*: AgentOS as a self-contained deployable container. Prerequisite for Gitea and dashboard. Stabilize the system first. See [`docs/planning/backlog/backlog-containerization.md`](backlog/backlog-containerization.md).
 - **(16)** **Adjutant**: Cron-based maintenance + LLM-backed advisor. Runs inside the container.
 - **(17)** **Gitea Integration** *(Backlog)*: Embedded Gitea for script repo hosting and human inspection. Depends on containerization. See [`docs/planning/backlog/backlog-gitea.md`](backlog/backlog-gitea.md).

--- a/docs/planning/backlog/backlog-multi-source-input.md
+++ b/docs/planning/backlog/backlog-multi-source-input.md
@@ -1,0 +1,46 @@
+# Backlog: Multi-Source Input
+
+## Summary
+
+Support an array of input sources rather than a single command channel, with the ability to add, revoke, and assign roles to sources at runtime.
+
+## Motivation
+
+The current Gist command channel stores a single Gist URL in `.env`. This works for a single operator but limits the system in several ways:
+
+- Only one human can send commands without sharing a Gist credential.
+- If a source is compromised, the only recourse is to rotate the Gist (requiring a redeploy or `.env` edit).
+- All input arrives over the same channel with no ability to distinguish source identity or apply per-source trust levels.
+
+## Concept
+
+Replace the single `GIST_URL` env var with a structured list of input sources. Each source has:
+
+- A **URL or identifier** (e.g., Gist ID, webhook path, file path)
+- A **channel type** (gist, file, webhook, etc.)
+- A **label** (human-readable name for the source, e.g., "primary-operator", "mobile")
+- An **active/revoked flag**
+
+The polling loop iterates all active sources and merges their inputs into the inbox.
+
+## Capabilities Enabled
+
+- **Multi-user access**: Different operators can send commands via separate Gists without sharing credentials.
+- **Compromised-source revocation**: Mark a source as revoked without touching other channels.
+- **Channel diversity**: Mix input types (Gist, local file, future HTTP endpoint) without pipeline changes.
+- **Per-source trust levels**: Future — assign different review stringency to untrusted vs. trusted sources.
+
+## Open Questions
+
+- Should source management itself be a command (i.e., operator sends "add source X" via existing channel)?
+- Where does the source list live — `.env`, `runtime/`, or an identity config file?
+- What happens when two sources deliver conflicting commands in the same poll cycle?
+
+## Dependencies
+
+- Gist command channel (ADR-0001) must be operational first.
+- Source revocation requires a persistent source registry (similar to `runtime/` state files).
+
+## Related
+
+- [ADR-0001: Gist-Based Command Channel](../../decisions/0001-gist-command-channel.md)

--- a/docs/planning/backlog/backlog.md
+++ b/docs/planning/backlog/backlog.md
@@ -17,6 +17,7 @@ Each item has a file in this directory. This index lists them in rough priority 
 9. **BIG_BROTHER Proactive Config Optimization** (`backlog-bb-optimization.md`) — Proactive mode for BB: analyzes execution logs and proposes config improvements on a per-invocation threshold, not just in response to RR flags.
 10. **Developer/Writer Branch-Based Script Staging** (`backlog-dw-branch-staging.md`) — Replace flat staging dir with git branch per DW session. Depends on Gitea integration.
 11. **Scenario CI via Claude Code Web** (`backlog-scenario-ci.md`) — Automated behavioral testing using ephemeral Claude Code web sessions as integration test environments. Validates end-to-end pipeline and self-authoring capability.
+12. **Multi-Source Input** (`backlog-multi-source-input.md`) — Support an array of input sources (multiple Gists, other channels) with per-source labels and revocation. Enables multi-user access and compromised-source revocation. Depends on Gist command channel (ADR-0001).
 
 ## Exploration Sketches
 


### PR DESCRIPTION
- ADR-0001: private GitHub Gist as pull-based command channel (inbox pattern,
  single-slot limitation, bootstrap cron, runtime/ directory)
- Roadmap: note Gist command channel as in-progress infrastructure in Tier 5
- Backlog: add multi-source input item (per-source labels, revocation, channel
  diversity); update backlog.md index
- CLAUDE.md: expand script frontmatter docs with concrete example and parsing rules

https://claude.ai/code/session_01PzkXd4z8Pt8f5x5EXoGUSF