### PR TITLE
feat: add pipeline breadcrumb progress messages

### DIFF
--- a/src/agents/lieutenant-planner.ts
+++ b/src/agents/lieutenant-planner.ts
@@ -129,6 +129,7 @@ export async function createDetailedPlanWithDW(
   while (result.missingScripts.length > 0 && dwCallCount < MAX_DW_CALLS) {
     const toCreate = result.missingScripts.slice(0, MAX_DW_CALLS - dwCallCount);
     verbose("LieutenantPlanner: commissioning scripts via DW", toCreate.map((s) => s.name));
+    if (options.adapter) await options.adapter.sendProgress("dw", `Developer/Writer: creating ${toCreate.length} missing script${toCreate.length === 1 ? "" : "s"}...`);
 
     const existingScripts = await listScripts(scriptsDir);
 
@@ -143,6 +144,7 @@ export async function createDetailedPlanWithDW(
         );
         dwCallCount++;
         verbose("LieutenantPlanner: DW script created", { name: missing.name, dwCallCount });
+        if (options.adapter) await options.adapter.sendProgress("dw", `Developer/Writer: script promoted (${dwCallCount}/${MAX_DW_CALLS})`);
       } catch (err) {
         verbose("LieutenantPlanner: DW script creation failed", {
           name: missing.name,

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -139,6 +139,7 @@ export async function handleRequest(
 
   // Step 2: General Planner creates a strategic plan (work assignments)
   verbose("Orchestrator: calling general planner", taskDescription);
+  if (adapter) await adapter.sendProgress("req", "General Planner: creating strategic plan...");
   const strategicPlan = await createStrategicPlan(
     client,
     taskDescription,
@@ -147,6 +148,7 @@ export async function handleRequest(
   );
 
   verbose("Orchestrator: strategic plan created", strategicPlan);
+  if (adapter) await adapter.sendProgress("req", `Strategic plan ready (${strategicPlan.assignments.length} assignment${strategicPlan.assignments.length === 1 ? "" : "s"})`);
   provenance.push({
     agentId: "planner",
     action: `created strategic plan ${strategicPlan.id}`,
@@ -311,6 +313,7 @@ export async function handleRequest(
   }
 
   // Step 4: Generate natural-language response
+  if (adapter) await adapter.sendProgress("req", "Orchestrator: synthesizing response...");
   const responsePrompt = buildResponsePrompt(
     userInput,
     taskDescription,

--- a/src/integration/pipeline.integration.test.ts
+++ b/src/integration/pipeline.integration.test.ts
@@ -831,6 +831,70 @@ describe("12. Per-agent clientFactory wiring", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Test 13 — Pipeline Breadcrumb Progress Messages  (mock-only)
+//
+// Validates: sendProgress() is called at key pipeline stages, and the
+// TestAdapter collects breadcrumb messages for inspection.
+// ---------------------------------------------------------------------------
+
+describe("13. Pipeline Breadcrumb Progress Messages", () => {
+  it.skipIf(USE_REAL_LLM)(
+    "emits progress breadcrumbs through the pipeline",
+    async () => {
+      const plansDir = await makeTmpPlansDir();
+      const jobsDir = await mkdtemp(join(tmpdir(), "writ-integ-breadcrumb-"));
+
+      try {
+        const client = createMockLLMClient();
+        const adapter = createTestAdapter();
+
+        const store = await createJobStore(jobsDir);
+        const executor = createDefaultJobExecutor({
+          clientFactory: (_agentId) => client,
+          identity,
+          scriptsDir: INSTANCE_SCRIPTS_DIR,
+          plansDir,
+          skipReview: true,
+          getStore: () => store,
+        });
+        const scheduler = createScheduler(store, executor, adapter);
+
+        await handleRequest(
+          client,
+          "List the files in the project root",
+          identity,
+          INSTANCE_SCRIPTS_DIR,
+          plansDir,
+          undefined,
+          true,
+          adapter,
+          scheduler
+        );
+
+        const messages = adapter.collected.progressMessages.map((p) => p.message);
+
+        // Orchestrator breadcrumbs
+        expect(messages.some((m) => m.includes("General Planner"))).toBe(true);
+        expect(messages.some((m) => m.includes("Strategic plan ready"))).toBe(true);
+        expect(messages.some((m) => m.includes("synthesizing response"))).toBe(true);
+
+        // Scheduler breadcrumbs
+        expect(messages.some((m) => m.includes("Starting:"))).toBe(true);
+        expect(messages.some((m) => m.includes("Complete:"))).toBe(true);
+
+        // DefaultJobExecutor breadcrumbs
+        expect(messages.some((m) => m.includes("Lieutenant Planner: generating detailed plan"))).toBe(true);
+        expect(messages.some((m) => m.includes("Executor: mapping plan to instructions"))).toBe(true);
+      } finally {
+        await rm(plansDir, { recursive: true, force: true });
+        await rm(jobsDir, { recursive: true, force: true });
+      }
+    },
+    30_000
+  );
+});
+
+// ---------------------------------------------------------------------------
 // Test 10 — Channel Routing  (mock-only, Task 5.5)
 //
 // Validates: jobs created by the orchestrator carry a non-empty channel array

--- a/src/io/CLIAdapter.test.ts
+++ b/src/io/CLIAdapter.test.ts
@@ -57,7 +57,7 @@ describe("CLIAdapter output methods", () => {
   it("sendProgress prints [jobId] message to stdout", () => {
     const adapter = createCLIAdapter();
     adapter.sendProgress("job-42", "running step 1 of 3");
-    expect(logSpy).toHaveBeenCalledWith("[job-42] running step 1 of 3");
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("[job-42] running step 1 of 3"));
   });
 
   it("onRequest stores handler (smoke test — handler called with input)", async () => {

--- a/src/io/CLIAdapter.ts
+++ b/src/io/CLIAdapter.ts
@@ -1,5 +1,6 @@
 import { createInterface } from "node:readline";
 import type { IOAdapter } from "./IOAdapter.js";
+import { easternTimestamp } from "../logger.js";
 
 export interface CLIAdapterOptions {
   prompt?: string;
@@ -40,7 +41,7 @@ export function createCLIAdapter(options: CLIAdapterOptions = {}): IOAdapter {
     },
 
     sendProgress(jobId: string, message: string): void {
-      console.log(`[${jobId}] ${message}`);
+      console.log(`[${easternTimestamp()}] [${jobId}] ${message}`);
     },
 
     requestConfirmation(summary: string, details?: string): Promise<boolean> {

--- a/src/jobs/defaultExecutor.ts
+++ b/src/jobs/defaultExecutor.ts
@@ -33,6 +33,7 @@ export function createDefaultJobExecutor(
     async execute(job: Job, adapter: IOAdapter | undefined): Promise<unknown> {
       switch (job.type) {
         case "execute_script": {
+          if (adapter) await adapter.sendProgress(job.id, "Executor: mapping plan to instructions...");
           let plan = job.plan ?? null;
 
           // If no plan is directly attached, attempt to resolve it from the first dependency job's result.
@@ -53,6 +54,7 @@ export function createDefaultJobExecutor(
         }
 
         case "develop_script": {
+          if (adapter) await adapter.sendProgress(job.id, "Developer/Writer: generating script...");
           const existingScripts = await listScripts(scriptsDir);
           return generateScript(
             clientFactory("developer-writer"),
@@ -62,6 +64,7 @@ export function createDefaultJobExecutor(
         }
 
         case "plan": {
+          if (adapter) await adapter.sendProgress(job.id, "Lieutenant Planner: generating detailed plan...");
           const assignment: WorkAssignment = {
             id: job.id,
             description: job.goal,

--- a/src/jobs/scheduler.ts
+++ b/src/jobs/scheduler.ts
@@ -83,6 +83,7 @@ export function createScheduler(
 
   async function executeJob(job: Job): Promise<void> {
     verbose("Scheduler: starting job", { id: job.id, type: job.type });
+    if (adapter) await adapter.sendProgress(job.id, `Starting: ${job.type}`);
     const updated = await store.updateJob(job.id, {
       status: "running",
       timestamps: { ...job.timestamps, started: easternTimestamp() },
@@ -96,6 +97,7 @@ export function createScheduler(
         timestamps: { ...updated.timestamps, completed: easternTimestamp() },
       });
       verbose("Scheduler: job completed", { id: job.id });
+      if (adapter) await adapter.sendProgress(job.id, `Complete: ${job.type}`);
       await processCallbacks(completed);
       notifyWaiters(completed);
     } catch (err) {
@@ -105,6 +107,7 @@ export function createScheduler(
         timestamps: { ...updated.timestamps, completed: easternTimestamp() },
       });
       verbose("Scheduler: job failed", { id: job.id, error: err instanceof Error ? err.message : String(err) });
+      if (adapter) await adapter.sendProgress(job.id, `Failed: ${job.type}`);
       await blockDependents(job.id);
       await processCallbacks(failed);
       notifyWaiters(failed);


### PR DESCRIPTION
## Summary
- Add progress breadcrumb messages to the pipeline to surface intermediate state during long-running operations

## Test plan
- [ ] Run pipeline end-to-end and verify breadcrumb messages appear at expected checkpoints
- [ ] Check that messages don't interfere with existing output formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)